### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you plan to build AvalancheGo from source, you will also need the following s
 Clone the AvalancheGo repository:
 
 ```sh
-git clone git@github.com:ava-labs/avalanchego.git
+git clone https://github.com/ava-labs/avalanchego.git
 cd avalanchego
 ```
 


### PR DESCRIPTION
Fix wrong git url git@github.com:ava-labs/avalanchego.git to https://github.com/ava-labs/avalanchego.git


Please go through this checklist and check the item relevant, delete unrelevant ones and provide related links

* [ ] Does this PR change a config flag?
  * PR for docs under https://github.com/ava-labs/avalanche-docs/pulls
  * PR for Avash under https://github.com/ava-labs/avash/pulls
  * PR for AvalancheJS under https://github.com/ava-labs/avalanchejs/pulls
* [ ] Does this PR change a Prometheus metric?
  * PR for docs (for Granfana) under https://github.com/ava-labs/avalanche-docs/pulls
* [ ] Does this PR change an API?
  * PR for docs under https://github.com/ava-labs/avalanche-docs/pulls
  * PR for AvalancheJS under https://github.com/ava-labs/avalanchejs/pulls
* [ ] Is this change backward compatible with the previous version of AvalancheGo?
* [ ] Does this PR change where AvalancheGo looks for/puts files?
* [ ] Does this PR change the serialization of anything?
* [ ] Does this PR require a network upgrade?
* [ ] Does this PR require a database upgrade?
* [ ] Does this PR change any P2P message types?
* [ ] If this PR is a release, do the release notes reflect all the changes above?

* If you have other related issues/tickets, please link them here
