### PR TITLE
Fix docker image url

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ To check the built image, run:
 docker image ls
 ```
 
-The image should be tagged as `avaplatform/avalanchego:xxxxxxxx`, where `xxxxxxxx` is the shortened commit of the Avalanche source it was built from. To run the avalanche node, run:
+The image should be tagged as `avaplatform/avalanchego`. To run the avalanche node, run:
 
 ```sh
-docker run -ti -p 9650:9650 -p 9651:9651 avaplatform/avalanchego:xxxxxxxx /avalanchego/build/avalanchego
+docker run -ti -p 9650:9650 -p 9651:9651 avaplatform/avalanchego /avalanchego/build/avalanchego
 ```
 
 ## Running Avalanche


### PR DESCRIPTION
Please go through this checklist and check the item relevant, delete unrelevant ones and provide related links

* [ ] Does this PR change a config flag?
  * PR for docs under https://github.com/ava-labs/avalanche-docs/pulls
  * PR for Avash under https://github.com/ava-labs/avash/pulls
  * PR for AvalancheJS under https://github.com/ava-labs/avalanchejs/pulls
* [ ] Does this PR change a Prometheus metric?
  * PR for docs (for Granfana) under https://github.com/ava-labs/avalanche-docs/pulls
* [ ] Does this PR change an API?
  * PR for docs under https://github.com/ava-labs/avalanche-docs/pulls
  * PR for AvalancheJS under https://github.com/ava-labs/avalanchejs/pulls
* [ ] Is this change backward compatible with the previous version of AvalancheGo?
* [ ] Does this PR change where AvalancheGo looks for/puts files?
* [ ] Does this PR change the serialization of anything?
* [ ] Does this PR require a network upgrade?
* [ ] Does this PR require a database upgrade?
* [ ] Does this PR change any P2P message types?
* [ ] If this PR is a release, do the release notes reflect all the changes above?

* If you have other related issues/tickets, please link them here
